### PR TITLE
Add WooCommerce payment gateway integration

### DIFF
--- a/includes/classes/Builders/admin-settings/payments/woocommerce.php
+++ b/includes/classes/Builders/admin-settings/payments/woocommerce.php
@@ -1,24 +1,19 @@
 <?php
 /**
- * Payment Woocomerce Tab Settings.
+ * Payment WooCommerce Tab Settings.
  *
  * @since 6.2.0
  */
-$is_wte_woocommerce_active = defined( 'WPTRAVELENGINE_WC_PAYMENTS_FILE__' );
-$is_woocomerce_active      = defined( 'WC_PLUGIN_FILE' );
-$active_extensions         = apply_filters( 'wpte_settings_get_global_tabs', array() );
-$file_path                 = $active_extensions['wpte-payment']['sub_tabs']['woocommerce']['content_path'] ?? '';
-if ( ! file_exists( $file_path ) ) {
-	return array();
-}
+$is_woocomerce_active = defined( 'WC_PLUGIN_FILE' );
+
 return apply_filters(
-	'payment_woocommerce',
-	array(
-		'is_active' => ( $is_wte_woocommerce_active && $is_woocomerce_active ) ? true : false,
-		'title'     => __( 'WooCommerce', 'wp-travel-engine' ),
-		'order'     => 75,
-		'id'        => 'payment-woocommerce',
-		'fields'    => array(
+        'payment_woocommerce',
+        array(
+                'is_active' => $is_woocomerce_active ? true : false,
+                'title'     => __( 'WooCommerce', 'wp-travel-engine' ),
+                'order'     => 75,
+                'id'        => 'payment-woocommerce',
+                'fields'    => array(
 			array(
 				'field_type' => 'DEBUG_MODE',
 				'name'       => 'debug_mode',

--- a/includes/classes/Core/Booking/BookingProcess.php
+++ b/includes/classes/Core/Booking/BookingProcess.php
@@ -643,10 +643,10 @@ class BookingProcess {
 		 * If WooCommerce integration is active, let it continue the process ignoring the form validation errors since it is handled by WooCommerce.
 		 * @since 6.5.7
 		 */
-		$enable_woocommerce_gateway = wptravelengine_settings()->get( 'use_woocommerce_payment_gateway', false );
-		if ( defined( 'WPTRAVELENGINE_WC_PAYMENTS_FILE__' ) && $enable_woocommerce_gateway ) {
-			return true;
-		}
+                $enable_woocommerce_gateway = wptravelengine_settings()->get( 'use_woocommerce_payment_gateway', false );
+                if ( $enable_woocommerce_gateway ) {
+                        return true;
+                }
 
 		return ! $result->has_errors();
 	}

--- a/includes/classes/Core/Controllers/RestAPI/V2/Settings.php
+++ b/includes/classes/Core/Controllers/RestAPI/V2/Settings.php
@@ -934,11 +934,7 @@ class Settings {
 
 		$settings[ 'payment_gateways' ] = apply_filters( 'wptravelengine_rest_payment_gateways', $settings[ 'payment_gateways' ], $plugin_settings );
 
-		$active_extensions = apply_filters( 'wpte_settings_get_global_tabs', array() );
-		$file_path         = $active_extensions[ 'wpte-payment' ][ 'sub_tabs' ][ 'woocommerce' ][ 'content_path' ] ?? '';
-		if ( file_exists( $file_path ) ) {
-			$settings[ 'enable_woocommerce_gateway' ] = wptravelengine_toggled( $plugin_settings->get( 'use_woocommerce_payment_gateway', 'no' ) );
-		}
+                $settings[ 'enable_woocommerce_gateway' ] = wptravelengine_toggled( $plugin_settings->get( 'use_woocommerce_payment_gateway', 'no' ) );
 
 		$payments_order = Options::get( 'wptravelengine_payment_gateways', array() );
 

--- a/includes/classes/Filters/schemas/woocommerce.php
+++ b/includes/classes/Filters/schemas/woocommerce.php
@@ -1,19 +1,13 @@
 <?php
 /**
- * Woocommerce Payment Extenstion Schmea.
+ * WooCommerce Payment Extension Schema.
  *
  * @since 6.2.0
  */
 
-$active_extensions         = apply_filters( 'wpte_settings_get_global_tabs', array() );
-$file_path                 = $active_extensions['wpte-payment']['sub_tabs']['woocommerce']['content_path'] ?? '';
-if ( ! file_exists( $file_path ) ) {
-	return array();
-}
-
 return array(
-	'enable_woocommerce_gateway' => array(
-		'description' => __( 'Use WooCommerce Payment Gateway for Payments', 'wp-travel-engine' ),
-		'type'        => 'boolean',
-	),
+        'enable_woocommerce_gateway' => array(
+                'description' => __( 'Use WooCommerce Payment Gateway for Payments', 'wp-travel-engine' ),
+                'type'        => 'boolean',
+        ),
 );

--- a/includes/classes/PaymentGateways/PaymentGateways.php
+++ b/includes/classes/PaymentGateways/PaymentGateways.php
@@ -9,6 +9,7 @@ namespace WPTravelEngine\PaymentGateways;
 
 use WPTravelEngine\Abstracts\PaymentGateway;
 use WPTravelEngine\PaymentGateways\StandardPaypal\Gateway as PayPalGateway;
+use WPTravelEngine\PaymentGateways\WooCommerce;
 use WPTravelEngine\Traits\Singleton;
 
 /**
@@ -103,12 +104,16 @@ class PaymentGateways {
 	 */
 	protected function register_gateways() {
 
-		$payment_gateways = array(
-			'booking_only'         => new BookingOnly(),
-			'paypal_payment'       => new PayPalGateway(),
-			'direct_bank_transfer' => new DirectBankTransfer(),
-			'check_payments'       => new CheckPayment(),
-		);
+                $payment_gateways = array(
+                        'booking_only'         => new BookingOnly(),
+                        'paypal_payment'       => new PayPalGateway(),
+                        'direct_bank_transfer' => new DirectBankTransfer(),
+                        'check_payments'       => new CheckPayment(),
+                );
+
+                if ( class_exists( '\\WooCommerce' ) ) {
+                        $payment_gateways['woocommerce'] = new WooCommerce();
+                }
 
 		$gateways = apply_filters_deprecated( 'wp_travel_engine_available_payment_gateways', [ array() ], '6.0.0' );
 

--- a/includes/classes/PaymentGateways/WooCommerce.php
+++ b/includes/classes/PaymentGateways/WooCommerce.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * WooCommerce Payment Gateway.
+ *
+ * @package WPTravelEngine\PaymentGateways
+ */
+
+namespace WPTravelEngine\PaymentGateways;
+
+use WPTravelEngine\Core\Models\Post\Booking;
+use WPTravelEngine\Core\Models\Post\Payment;
+use WPTravelEngine\Core\Booking\BookingProcess;
+
+/**
+ * WooCommerce Payment Gateway integration.
+ *
+ * Redirects WTE bookings to WooCommerce checkout and syncs order statuses.
+ *
+ * @since 6.0.0
+ */
+class WooCommerce extends BaseGateway {
+
+    /**
+     * Setup hooks for WooCommerce integration.
+     */
+    public function __construct() {
+        if ( class_exists( '\\WooCommerce' ) ) {
+            add_action( 'init', [ $this, 'maybe_boot_wc_checkout' ] );
+            add_action( 'woocommerce_checkout_create_order', [ $this, 'attach_booking_to_order' ], 10, 2 );
+            add_action( 'woocommerce_order_status_changed', [ $this, 'sync_order_status' ], 10, 4 );
+            add_action( 'updated_post_meta', [ $this, 'sync_booking_status_to_order' ], 10, 4 );
+        }
+    }
+
+    /** @inheritDoc */
+    public function get_gateway_id(): string {
+        return 'woocommerce';
+    }
+
+    /** @inheritDoc */
+    public function get_label(): string {
+        return __( 'WooCommerce', 'wp-travel-engine' );
+    }
+
+    /** @inheritDoc */
+    public function get_public_label(): string {
+        return __( 'Pay with WooCommerce', 'wp-travel-engine' );
+    }
+
+    /** @inheritDoc */
+    public function get_info(): string {
+        return __( 'Checkout securely using WooCommerce payment gateways.', 'wp-travel-engine' );
+    }
+
+    /** @inheritDoc */
+    public function get_description(): string {
+        return __( 'Redirect to WooCommerce checkout to complete the booking payment.', 'wp-travel-engine' );
+    }
+
+    /**
+     * Process the payment by redirecting to WooCommerce checkout.
+     */
+    public function process_payment( Booking $booking, Payment $payment, BookingProcess $booking_instance ): void {
+        $payable = $payment->get_meta( 'payable' );
+        $payload = [
+            'booking_id' => $booking->ID,
+            'payment_id' => $payment->get_id(),
+            'amount'     => $payable['amount'] ?? 0,
+        ];
+
+        $token = wp_generate_password( 12, false );
+        set_transient( "wte_wc_{$token}", $payload, MINUTE_IN_SECONDS * 30 );
+
+        $checkout_url = add_query_arg( [ 'wte_wc_token' => $token ], wc_get_checkout_url() );
+        wp_redirect( $checkout_url );
+        exit;
+    }
+
+    /**
+     * Prepare WooCommerce checkout with booking data.
+     */
+    public function maybe_boot_wc_checkout() {
+        if ( ! function_exists( 'WC' ) || ! is_checkout() ) {
+            return;
+        }
+
+        $token = isset( $_GET['wte_wc_token'] ) ? sanitize_text_field( wp_unslash( $_GET['wte_wc_token'] ) ) : '';
+        if ( empty( $token ) ) {
+            return;
+        }
+
+        $payload = get_transient( "wte_wc_{$token}" );
+        if ( ! $payload ) {
+            return;
+        }
+
+        WC()->cart->empty_cart();
+        WC()->cart->add_fee( __( 'Trip Payment', 'wp-travel-engine' ), (float) $payload['amount'], false );
+        WC()->session->set( 'wte_wc_payload', $payload );
+    }
+
+    /**
+     * Attach booking information to the WooCommerce order.
+     *
+     * @param \WC_Order $order Order object.
+     */
+    public function attach_booking_to_order( $order, $data ) {
+        $payload = WC()->session->get( 'wte_wc_payload' );
+        if ( empty( $payload ) ) {
+            return;
+        }
+
+        $order->update_meta_data( '_wte_booking_id', $payload['booking_id'] );
+        $order->update_meta_data( '_wte_payment_id', $payload['payment_id'] );
+
+        $booking = Booking::make( $payload['booking_id'] );
+        $booking->set_meta( '_wte_wc_order_id', $order->get_id() )->save();
+    }
+
+    /**
+     * Sync WooCommerce order status changes to booking status.
+     */
+    public function sync_order_status( $order_id, $old_status, $new_status, $order ) {
+        $booking_id = $order->get_meta( '_wte_booking_id' );
+        if ( ! $booking_id ) {
+            return;
+        }
+
+        $map = [
+            'completed'  => 'completed',
+            'processing' => 'booked',
+            'failed'     => 'failed',
+            'cancelled'  => 'canceled',
+            'refunded'   => 'refunded',
+        ];
+
+        if ( isset( $map[ $new_status ] ) ) {
+            Booking::make( $booking_id )->update_status( $map[ $new_status ] );
+        }
+    }
+
+    /**
+     * Sync booking status updates back to WooCommerce order.
+     */
+    public function sync_booking_status_to_order( $meta_id, $object_id, $meta_key, $_meta_value ) {
+        if ( 'wp_travel_engine_booking_status' !== $meta_key ) {
+            return;
+        }
+
+        $order_id = get_post_meta( $object_id, '_wte_wc_order_id', true );
+        if ( ! $order_id ) {
+            return;
+        }
+
+        $map = [
+            'completed' => 'completed',
+            'booked'    => 'processing',
+            'failed'    => 'failed',
+            'canceled'  => 'cancelled',
+            'refunded'  => 'refunded',
+        ];
+
+        $status = get_post_meta( $object_id, 'wp_travel_engine_booking_status', true );
+        if ( isset( $map[ $status ] ) ) {
+            $order = wc_get_order( $order_id );
+            if ( $order && $order->get_status() !== $map[ $status ] ) {
+                $order->update_status( $map[ $status ] );
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate WooCommerce as a payment gateway for WP Travel Engine bookings
- add settings and REST API support for enabling WooCommerce payments
- allow WooCommerce orders and WTE bookings to sync their statuses

## Testing
- `php -l includes/classes/PaymentGateways/WooCommerce.php`
- `php -l includes/classes/PaymentGateways/PaymentGateways.php`
- `php -l includes/classes/Builders/admin-settings/payments/woocommerce.php`
- `php -l includes/classes/Filters/schemas/woocommerce.php`
- `php -l includes/classes/Core/Controllers/RestAPI/V2/Settings.php`
- `php -l includes/classes/Core/Booking/BookingProcess.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a4253eac8327bcf528f38f5ecfc9